### PR TITLE
[CMYK-216] 자주 사용한 말(키워드) 추출

### DIFF
--- a/app/api/diary_api.py
+++ b/app/api/diary_api.py
@@ -48,14 +48,10 @@ async def to_diary(body: DiaryRequest):
     #     ]
     # ]
 
-    # NOTE 2. 한줄평 요약
-    # TODO: 한줄평 요약
-    daily_comment = "샘플 한줄평 요약"
-
-    # NOTE 3. 키워드 추출
+    # NOTE 2. 키워드 추출
     keyword = keyword_model.get_keywords(stories=stories, count=5)
 
-    # NOTE 4. 일기 생성
+    # NOTE 3. 일기 생성
     # 예외처리: 일기 생성 전, 일기를 생성하기 위한 문장 수가 충분한지 확인
     if sum(len(story) for story in stories) < 5: # 리스트에 있는 전체 문장 수가 5개 이상이어야 한다.
         raise ControlledException(ErrorCode.CHAT_COUNT_NOT_ENOUGH)
@@ -66,19 +62,23 @@ async def to_diary(body: DiaryRequest):
     # 예외처리: 일기로 아무 내용이 반환되지 않았는지 확인한다.
     if len(topics) < 1: raise ControlledException(ErrorCode.CAN_NOT_EXTRACT_DIARY)
 
-    # NOTE 5. 감정 분석
+    # NOTE 4. 감정 분석
     feeling = extract_emotions(topics)
 
-    # NOTE 6. 이미지 저장
+    # NOTE 5. 이미지 저장
     for topic in topics:
         content = topic["content"]
         # TODO: 이미지 저장하기
         topic.update({"url": f"TODO {content}"})
 
-    # NOTE 7. 에고 페르소나 수정
+    # NOTE 7. 한줄 요약 문장 생성
+    daily_comment = "샘플 한줄평 요약"
+
+    # NOTE 6. 에고 페르소나 수정
     # TODO: 에고 페르소나 저장
 
     # NOTE 8. FE 반환 response 객체 생성
+    # TODO: 문장 변경 가능성 있음.
     response = {
         "uid": body.user_id,
         "egoId": 1,
@@ -86,9 +86,8 @@ async def to_diary(body: DiaryRequest):
         "dailyComment": daily_comment,
         "createdAt": date.today(),
         "keywords": keyword,
-        "topics": topics,
+        "topics": topics
     }
-    print(response) # 테스트용 로그
 
     return CommonResponse(
         code=200,

--- a/app/api/diary_api.py
+++ b/app/api/diary_api.py
@@ -5,6 +5,7 @@ from app.api.common_response import CommonResponse
 from app.exception.exceptions import ControlledException, ErrorCode
 from app.models.postgres_client import postgres_client
 from app.models.diary_llm_model import diary_llm
+from app.models.keyword_model import keyword_model
 from datetime import date
 
 from app.services.kobert_handler import extract_emotions
@@ -52,8 +53,7 @@ async def to_diary(body: DiaryRequest):
     daily_comment = "샘플 한줄평 요약"
 
     # NOTE 3. 키워드 추출
-    # TODO: 키워드 추출
-    keyword = ["샘플1", "샘플2"]
+    keyword = keyword_model.get_keywords(stories=stories, count=5)
 
     # NOTE 4. 일기 생성
     # 예외처리: 일기 생성 전, 일기를 생성하기 위한 문장 수가 충분한지 확인

--- a/app/models/keyword_model.py
+++ b/app/models/keyword_model.py
@@ -1,0 +1,36 @@
+from keybert import KeyBERT
+from kiwipiepy import Kiwi
+from sentence_transformers import SentenceTransformer
+
+class KeywordModel:
+    __model = SentenceTransformer("snunlp/KR-SBERT-V40K-klueNLI-augSTS")  # 한국어 SBERT
+    __keyword_model = KeyBERT(__model)
+    __kiwi = Kiwi()
+
+    def get_keywords(self, stories:list[list[str]], count:int=5):
+        nouns_list = []
+
+        texts = [chat for story in stories for chat in story]
+        sentences = " ".join(text for text in texts)
+
+        for sentence in self.__kiwi.analyze(sentences):
+            nouns = [token.form for token in sentence[0] if token.tag.startswith('NN')]
+            if nouns:
+                nouns_list.extend(nouns)
+        result_text = ' '.join(nouns_list)
+
+        # TODO: 아키텍처(architecture)&환경(enviroment)에 따라 에러가 발생할 수 있다.
+        """
+        sklearn/utils/extmath.py:203: RuntimeWarning: divide by zero encountered in matmul
+          ret = a @ b
+        sklearn/utils/extmath.py:203: RuntimeWarning: overflow encountered in matmul
+          ret = a @ b
+        sklearn/utils/extmath.py:203: RuntimeWarning: invalid value encountered in matmul
+          ret = a @ b
+        참고: https://stackoverflow.com/questions/76527556/what-is-the-cause-of-runtimewarning-invalid-value-encountered-in-matmul-ret
+        """
+        original_value_keywords = self.__keyword_model.extract_keywords(result_text, keyphrase_ngram_range=(1, 1), top_n=count)
+        keywords = [keyword[0] for keyword in original_value_keywords]
+        return keywords
+
+keyword_model = KeywordModel()

--- a/app/models/keyword_model.py
+++ b/app/models/keyword_model.py
@@ -7,7 +7,10 @@ class KeywordModel:
     __keyword_model = KeyBERT(__model)
     __kiwi = Kiwi()
 
-    def get_keywords(self, stories:list[list[str]], count:int=5):
+    def get_keywords_vector_embedding(self, stories:list[list[str]], count:int=5):
+        """
+        KeyBERT를 통해 벡터 임베딩을 통한 코사인 유사도로 키워드 추출
+        """
         nouns_list = []
 
         texts = [chat for story in stories for chat in story]

--- a/app/models/keyword_model.py
+++ b/app/models/keyword_model.py
@@ -1,11 +1,38 @@
 from keybert import KeyBERT
 from kiwipiepy import Kiwi
+from krwordrank.word import KRWordRank
 from sentence_transformers import SentenceTransformer
 
 class KeywordModel:
     __model = SentenceTransformer("snunlp/KR-SBERT-V40K-klueNLI-augSTS")  # 한국어 SBERT
     __keyword_model = KeyBERT(__model)
     __kiwi = Kiwi()
+
+    def get_keywords_textranker(self, stories: list[list[str]], count: int = 5, beta=0.85, max_iter=10):
+        # KRWordRank는 호출할 때마다 새로 생성
+        wordrank_extractor = KRWordRank(
+            min_count=1,  # 단어의 최소 출현 빈도수 (그래프 생성 시)
+            max_length=100,  # 단어의 최대 길이
+            verbose=True
+        )
+
+        # 텍스트 준비
+        texts = [chat for story in stories for chat in story]
+        full_text = " ".join(texts)
+
+        # 명사 추출
+        nouns = [
+            token.form
+            for analyzed in self.__kiwi.analyze(full_text)
+            for token in analyzed[0]
+            if token.tag.startswith("NN")
+        ]
+        result_text = " ".join(nouns)
+
+        # 추출
+        keywords, _, _ = wordrank_extractor.extract([result_text], beta=beta, max_iter=max_iter)
+
+        return [word for word, _ in sorted(keywords.items(), key=lambda x: -x[1])[:count]]
 
     def get_keywords_vector_embedding(self, stories:list[list[str]], count:int=5):
         """
@@ -18,8 +45,7 @@ class KeywordModel:
 
         for sentence in self.__kiwi.analyze(sentences):
             nouns = [token.form for token in sentence[0] if token.tag.startswith('NN')]
-            if nouns:
-                nouns_list.extend(nouns)
+            if nouns: nouns_list.extend(nouns)
         result_text = ' '.join(nouns_list)
 
         # TODO: 아키텍처(architecture)&환경(enviroment)에 따라 에러가 발생할 수 있다.


### PR DESCRIPTION
### 변경사항
1. 키워드 추출 모델 추가(snunlp/KR-SBERT-V40K-klueNLI-augSTS 사용)
2. 한국어 형태소(명사) 분석기는 Kiwi를 사용한다. 
3. 키워드는 총 5개(default) 추출한다.

### 주의사항
1. 문자 메세지가 많으면 ErrorWarning 메세지가 나온다. 
  - 에러 발생원인은 scikit-learn 라이브러리에서 발생
2. 지연시간이 2초 정도 소요된다. 업데이트 예정
```
/Users/kmj/PycharmProjects/ego-server-fastapi/.venv/lib/python3.12/site-packages/sklearn/utils/extmath.py:203: RuntimeWarning: divide by zero encountered in matmul
  ret = a @ b
/Users/kmj/PycharmProjects/ego-server-fastapi/.venv/lib/python3.12/site-packages/sklearn/utils/extmath.py:203: RuntimeWarning: overflow encountered in matmul
  ret = a @ b
/Users/kmj/PycharmProjects/ego-server-fastapi/.venv/lib/python3.12/site-packages/sklearn/utils/extmath.py:203: RuntimeWarning: invalid value encountered in matmul
  ret = a @ b
```