### PR TITLE
[CMYK-230] 에고 페르소나 생성 API 구현

### DIFF
--- a/app/api/persona_api.py
+++ b/app/api/persona_api.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.api.common_response import CommonResponse
+from app.models.postgres_database import postgres_database
+
+router = APIRouter()
+
+class PersonaRequest(BaseModel):
+    """
+    에고 페르소나 JSON을 만드는데 필요한 정보들이다.
+    """
+    ego_id: Optional[str] = None
+    name: Optional[str] = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+    mbti: Optional[str] = None
+
+@router.post("/persona")
+async def create_persona(body: PersonaRequest):
+    # NOTE 1. 이미 존재하는 페르소나인지 조회한다.
+    if postgres_database.already_persona(ego_id=body.ego_id):
+        return CommonResponse(
+            code=-1,
+            message="이미 페르소나가 존재하는 에고입니다."
+        )
+
+    # NOTE 2. None이 아닌 값만 필터링해서 저장
+    persona = {k: v for k, v in body.items() if v is not None}
+
+    # NOTE 3. 에고 정보를 JSON으로 만들어 저장한다.
+    postgres_database.insert_persona(persona=persona)
+
+    return CommonResponse(
+        code=200,
+        message="페르소나를 생성됐습니다!"
+    )

--- a/app/api/persona_api.py
+++ b/app/api/persona_api.py
@@ -28,7 +28,7 @@ async def create_persona(body: PersonaRequest):
         )
 
     # NOTE 2. None이 아닌 값만 필터링해서 저장
-    persona = {k: v for k, v in body.items() if v is not None}
+    persona = {k: v for k, v in body.model_dump().items() if v is not None}
 
     # NOTE 3. 에고 정보를 JSON으로 만들어 저장한다.
     postgres_database.insert_persona(persona=persona)

--- a/app/api/persona_api.py
+++ b/app/api/persona_api.py
@@ -31,7 +31,7 @@ async def create_persona(body: PersonaRequest):
     persona = {k: v for k, v in body.model_dump().items() if v is not None}
 
     # NOTE 3. 에고 정보를 JSON으로 만들어 저장한다.
-    postgres_database.insert_persona(persona=persona)
+    postgres_database.insert_persona(ego_id= body.ego_id, persona=persona)
 
     return CommonResponse(
         code=200,

--- a/app/api/persona_api.py
+++ b/app/api/persona_api.py
@@ -12,7 +12,7 @@ class PersonaRequest(BaseModel):
     """
     에고 페르소나 JSON을 만드는데 필요한 정보들이다.
     """
-    ego_id: Optional[str] = None
+    ego_id: str
     name: Optional[str] = None
     age: Optional[int] = None
     gender: Optional[str] = None
@@ -28,7 +28,7 @@ async def create_persona(body: PersonaRequest):
         )
 
     # NOTE 2. None이 아닌 값만 필터링해서 저장
-    persona = {k: v for k, v in body.model_dump().items() if v is not None}
+    persona = {k: v for k, v in body.model_dump().items() if k != "ego_id" and v is not None}
 
     # NOTE 3. 에고 정보를 JSON으로 만들어 저장한다.
     postgres_database.insert_persona(ego_id= body.ego_id, persona=persona)

--- a/app/exception/exceptions.py
+++ b/app/exception/exceptions.py
@@ -10,7 +10,7 @@ class ErrorCode(Enum):
 
     # 음성&채팅 메세지
     PASSAGE_NOT_FOUND = (-100, "해당 passage_id로 조회된 본문(passage)이 없습니다.")
-    PERSONA_NOT_FOUNT = (-101, "해당 ego_id로 조회된 페르소나(persona)가 없습니다.")
+    PERSONA_NOT_FOUND = (-101, "해당 ego_id로 조회된 페르소나(persona)가 없습니다.")
     # 일기 생성
     CHAT_COUNT_NOT_ENOUGH = (-201, "일기를 만들기 위한 문장 수가 부족합니다.")
     CAN_NOT_EXTRACT_DIARY = (-202, "아무런 주제도 도출되지 못했습니다.")

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ import sys
 import importlib.util
 
 from fastapi import FastAPI, APIRouter
-from app.api import chat_api, voice_chat_api, fal_api, diary_api
+from app.api import chat_api, voice_chat_api, fal_api, diary_api, persona_api
 from app.exception.exception_handler import register_exception_handlers
 from app.services.tts_infer import ensure_init
 
@@ -70,6 +70,6 @@ app.include_router(chat_api.router,    prefix="/api", tags=["chat"])
 app.include_router(voice_chat_api.router, prefix="/api", tags=["voice-chat"])
 app.include_router(fal_api.router, prefix="/api", tags=["image"])
 app.include_router(diary_api.router, prefix="/api", tags=["diary"])
-app.include_router(diary_api.router, prefix="/api", tags=["persona"])
+app.include_router(persona_api.router, prefix="/api", tags=["persona"])
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -70,5 +70,6 @@ app.include_router(chat_api.router,    prefix="/api", tags=["chat"])
 app.include_router(voice_chat_api.router, prefix="/api", tags=["voice-chat"])
 app.include_router(fal_api.router, prefix="/api", tags=["image"])
 app.include_router(diary_api.router, prefix="/api", tags=["diary"])
+app.include_router(diary_api.router, prefix="/api", tags=["persona"])
 
 

--- a/app/models/postgres_database.py
+++ b/app/models/postgres_database.py
@@ -24,33 +24,30 @@ class PostgresDatabase:
         self.__database.close()
         self.__cursor.close()
 
-    def insert_persona(self, persona_name: str, persona_json: dict):
-        sql = "INSERT INTO persona (name, persona) VALUES (%s, %s)"
-        self.__cursor.execute(sql, (persona_name, json.dumps(persona_json), ))
+    def insert_persona(self, persona: dict):
+        sql = "INSERT INTO persona (persona) VALUES (%s)"
+        self.__cursor.execute(sql, (json.dumps(persona),))
         self.__database.commit()
 
-    def update_persona(self, persona_id: int, persona_json: dict):
+    def update_persona(self, ego_id: str, persona_json: dict):
         sql = "UPDATE persona SET persona = %s WHERE persona_id = %s"
-        self.__cursor.execute(sql, (json.dumps(persona_json), persona_id, ))
+        self.__cursor.execute(sql, (json.dumps(persona_json), ego_id,))
         self.__database.commit()
 
-    def select_persona_to_id(self, persona_id: int):
+    def select_persona_to_id(self, ego_id: str):
         sql = "SELECT * FROM persona WHERE persona_id = %s"
-        self.__cursor.execute(sql, (persona_id, ))
+        self.__cursor.execute(sql, (ego_id,))
         result = self.__cursor.fetchall()
 
-        if len(result) == 0: return [
-            persona_id,
-            "카리나",
-            {
-                "name": "카리나",
-                "age": 25,
-                "gender": "여자",
-                "mbti": "ENTP",
-                "updated_at": datetime.now().isoformat()
-            }
-        ] # 페르소나 조회 실패 시, 예외처리 # TODO: 사용자 생성 업데이트 되면, 제거할 것
+        if len(result) == 0: raise ControlledException(ErrorCode.PERSONA_NOT_FOUND)
         else: return result[0] # 페르소나 결과 반환
+
+    def already_persona(self, ego_id: str) -> bool:
+        sql = "SELECT * FROM persona WHERE persona_id = %s"
+        self.__cursor.execute(sql, (ego_id,))
+        result = self.__cursor.fetchall()
+        if len(result) == 0: return False
+        else: return True
 
     @staticmethod
     def search_all_chat(user_id: str, target_time: datetime):
@@ -98,7 +95,7 @@ class PostgresDatabase:
         return user_all_chat_room_log
 
     def create_persona(self):
-        sql = "CREATE TABLE persona (persona_id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL UNIQUE, persona JSON NOT NULL)"
+        sql = "CREATE TABLE persona (ego_id INT PRIMARY KEY, persona JSON NOT NULL)"
         self.__cursor.execute(sql)
         self.__database.commit()
 

--- a/app/models/postgres_database.py
+++ b/app/models/postgres_database.py
@@ -30,12 +30,12 @@ class PostgresDatabase:
         self.__database.commit()
 
     def update_persona(self, ego_id: str, persona_json: dict):
-        sql = "UPDATE persona SET persona = %s WHERE persona_id = %s"
+        sql = "UPDATE persona SET persona = %s WHERE ego_id = %s"
         self.__cursor.execute(sql, (json.dumps(persona_json), ego_id,))
         self.__database.commit()
 
     def select_persona_to_id(self, ego_id: str):
-        sql = "SELECT * FROM persona WHERE persona_id = %s"
+        sql = "SELECT * FROM persona WHERE ego_id = %s"
         self.__cursor.execute(sql, (ego_id,))
         result = self.__cursor.fetchall()
 
@@ -43,7 +43,7 @@ class PostgresDatabase:
         else: return result[0] # 페르소나 결과 반환
 
     def already_persona(self, ego_id: str) -> bool:
-        sql = "SELECT * FROM persona WHERE persona_id = %s"
+        sql = "SELECT * FROM persona WHERE ego_id = %s"
         self.__cursor.execute(sql, (ego_id,))
         result = self.__cursor.fetchall()
         if len(result) == 0: return False

--- a/app/models/postgres_database.py
+++ b/app/models/postgres_database.py
@@ -24,9 +24,9 @@ class PostgresDatabase:
         self.__database.close()
         self.__cursor.close()
 
-    def insert_persona(self, persona: dict):
-        sql = "INSERT INTO persona (persona) VALUES (%s)"
-        self.__cursor.execute(sql, (json.dumps(persona),))
+    def insert_persona(self, ego_id: str, persona: dict):
+        sql = "INSERT INTO persona (ego_id, persona) VALUES (%s, %s)"
+        self.__cursor.execute(sql, (ego_id, json.dumps(persona),))
         self.__database.commit()
 
     def update_persona(self, ego_id: str, persona_json: dict):

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -23,7 +23,7 @@ def chat_stream(prompt: str, config: SessionConfig):
     # asyncio.create_task(save_graphdb(session_id=session_id, user_answer=prompt))
 
     rag_prompt = get_rag_prompt(ego_id=ego_id, user_speak=prompt)
-    persona = persona_store.get_persona(persona_id=ego_id)
+    persona = persona_store.get_persona(ego_id=ego_id)
 
     for chunk in main_llm.get_chain().stream(
         input = {

--- a/app/services/session_config.py
+++ b/app/services/session_config.py
@@ -4,5 +4,5 @@ class SessionConfig:
         user_id : str,
         ego_id : str,
     ):
-        self.user_id = user_id,
+        self.user_id = user_id
         self.ego_id = ego_id


### PR DESCRIPTION
### 변경사항
1. 에고 페르소나 생성 API 구현: ego_id와 페르소나 JSON이 매핑되어있는 테이블에 레코드를 추가하는 API이다.
2. (이번에 추가된) persona 테이블은 hub db의 ego_id와 같은 id를 공유한다. primary를 직접적으로 주입해야 생성이 된다. (AUTO_INCREMENT 설정 안함)

### 이미지
#### Swagger API
![image](https://github.com/user-attachments/assets/2a09f685-6014-4d7f-a018-847cff228341)
#### 결과 - 저장 성공
<img width="564" alt="image" src="https://github.com/user-attachments/assets/0a4c961f-c393-46a2-b93b-be9c1da129f9" />
